### PR TITLE
Avoid segfault when configs[parentConfig].Module.ModuleCalls[sth] is nill

### DIFF
--- a/map.go
+++ b/map.go
@@ -242,11 +242,10 @@ func (r *rover) GenerateModuleMap(parent *Resource, parentModule string) {
 
 				parent.Children[id] = re
 			}
-
 		} else if rs.Type == ResourceTypeModule {
 			re.Name = strings.Split(id, ".")[len(strings.Split(id, "."))-1]
 
-			if configured && !childIndex.MatchString(id) {
+			if configured && !childIndex.MatchString(id) && configs[parentConfig].Module.ModuleCalls[matchBrackets.ReplaceAllString(re.Name, "")] != nil {
 				fname := filepath.Base(configs[parentConfig].Module.ModuleCalls[matchBrackets.ReplaceAllString(re.Name, "")].Pos.Filename)
 				re.Line = &configs[parentConfig].Module.ModuleCalls[matchBrackets.ReplaceAllString(re.Name, "")].Pos.Line
 


### PR DESCRIPTION
Avoid segfault when configs[parentConfig].Module.ModuleCalls[sth] is nill